### PR TITLE
Fix which-key registration

### DIFF
--- a/.config/nvim/lua/config/keymap/post.lua
+++ b/.config/nvim/lua/config/keymap/post.lua
@@ -95,4 +95,4 @@ wk.add({
 
 	{ "<leader>a", group = "AI" },
 	--{ "<leader>aX", copilot.toggle_auto_trigger(), desc = "Toggle Auto Trigger" },
-}, { mode = "n", prexif = "" })
+}, { mode = "n", prefix = "" })

--- a/.config/nvim/lua/config/lsp/on-attach.lua
+++ b/.config/nvim/lua/config/lsp/on-attach.lua
@@ -21,13 +21,13 @@ local on_attach = function(_, bufnr)
 			noremap = true,
 			silent = false,
 		},
-	}, { mode = "n", prexif = "" })
+        }, { mode = "n", prefix = "" })
 
 	wk.add({
 		{ "gd", "<cmd> :Lspsaga peek_definition <cr>", desc = "Peek Definition" },
 		{ "gr", telescope.lsp_references, desc = "Find References" },
 		{ "K", vim.lsp.buf.hover, desc = "Hover Documentation" },
-	}, { mode = "n", prexif = "" })
+        }, { mode = "n", prefix = "" })
 
 	autocmd({ "BufWritePost" }, {
 		callback = function()


### PR DESCRIPTION
## Summary
- correct `which-key` option to `prefix` in keyboard setup and LSP attach logic

## Testing
- `grep -R "prexif" -n`

------
https://chatgpt.com/codex/tasks/task_e_685f13d4709c832baf736ea1577b7644