### PR TITLE
Setup custom theme with colorbuddy

### DIFF
--- a/.config/nvim/lua/config/themes/moonlander.lua
+++ b/.config/nvim/lua/config/themes/moonlander.lua
@@ -1,5 +1,5 @@
 local colorbuddy = require("colorbuddy")
---colorbuddy.colorscheme("moonlander")
+colorbuddy.colorscheme("moonlander")
 
 local Color = colorbuddy.Color
 local Group = colorbuddy.Group

--- a/.config/nvim/lua/plugins/colorbuddy.lua
+++ b/.config/nvim/lua/plugins/colorbuddy.lua
@@ -1,0 +1,8 @@
+return {
+    "tjdevries/colorbuddy.nvim",
+    lazy = false,
+    priority = 1000,
+    config = function()
+        require("config.themes.moonlander")
+    end,
+}

--- a/.config/nvim/lua/plugins/extra.lua
+++ b/.config/nvim/lua/plugins/extra.lua
@@ -111,8 +111,4 @@ return {
 			"nvim-tree/nvim-web-devicons",
 		},
 	},
-
-	{
-		"tjdevries/colorbuddy.nvim",
-	},
 }


### PR DESCRIPTION
## Summary
- switch to using `colorbuddy` to load a local theme
- add a plugin file to configure colorbuddy
- remove the previous colorbuddy entry

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6886532e4168832b96be1a22093f3f00